### PR TITLE
Update plugin compatibility to support 251 platform version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- Adding support for upcoming 251 platform version
+
 ## [1.0.1] - 2024-12-27
 
 ### Fixed

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,7 +24,7 @@ pluginGroup=com.pedrollanca.loveframeworksupport
 pluginName=love-framework-support
 pluginRepositoryUrl = https://github.com/pedrollanca/intellij-love-framework
 # SemVer format -> https://semver.org
-pluginVersion=1.0.1
+pluginVersion=1.0.2
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 233

--- a/gradle.properties
+++ b/gradle.properties
@@ -28,7 +28,7 @@ pluginVersion=1.0.1
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 233
-pluginUntilBuild=243.*
+pluginUntilBuild=251.*
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
 platformType = IC


### PR DESCRIPTION
Extended the `pluginUntilBuild` property in `gradle.properties` to allow compatibility with the 251 platform version. Updated the changelog to reflect this enhancement.